### PR TITLE
Make 'Posts' sidebar into 'Recent Posts'

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,10 +62,11 @@
             {% if site.blog == true %}
               <div class="posts-list">
                 <a href="{{ '/blog' | prepend: site.baseurl }}">
-                  <h4>Posts:</h4>
+                  <h4>Recent Posts:</h4>
                 </a>
                 <ul>
-                  {% for post in site.posts %}
+                  {% for i in (1..site.recent_posts) %}
+                     {% assign post = site.posts[i] %}
                   <li>
                     <a href="{{ post.url | prepend: site.baseurl  }}">{{ post.title }}</a>
                   </li>


### PR DESCRIPTION
The 'Posts' section in the sidebar gets a little busy if you've got a blog that's been around awhile. I made a small change that addresses that, and figured I may as well send a PR to see if you want to incorporate it.

Define `recent_posts` in `_config.yml` to limit the number of posts displayed.